### PR TITLE
feat: added legacy theme header and footer i18n strings

### DIFF
--- a/translations/edx-platform/conf/locale/en/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/en/LC_MESSAGES/django.po
@@ -13072,11 +13072,6 @@ msgstr ""
 msgid "edX and Open edX are registered trademarks of edX LLC."
 msgstr ""
 
-#. MITx Online theme - navbar-authenticated.html
-#: lms/templates/header/navbar-authenticated.html
-#. Translators: This is short for "System administration".
-msgid "Sysadmin"
-msgstr ""
 
 #. MITx Online theme - navbar-authenticated.html, user_dropdown.html
 #: lms/templates/header/navbar-authenticated.html
@@ -13116,7 +13111,7 @@ msgstr ""
 
 #. MITx Online theme - user_dropdown.html
 #: lms/templates/header/user_dropdown.html
-msgid "Accounts"
+msgid "Settings"
 msgstr ""
 
 #. MITx Online theme - user_dropdown.html
@@ -13128,4 +13123,25 @@ msgstr ""
 #: lms/templates/header/navbar-logo-header.html
 #, python-brace-format
 msgid "{platform_name} Home Page"
+msgstr ""
+
+#. MITx Online theme - footer.html
+#: lms/templates/footer.html
+msgid "Contact Us"
+msgstr ""
+
+#. MITx Online theme - footer.html
+#: lms/templates/footer.html
+msgid "Terms of Service"
+msgstr ""
+
+
+#. MITx Online theme - navbar-authenticated.html
+#: lms/templates/header/navbar-authenticated.html
+msgid "Courses"
+msgstr ""
+
+#. MITx Online theme - navbar-authenticated.html
+#: lms/templates/header/navbar-authenticated.html
+msgid "Programs"
 msgstr ""

--- a/translations/edx-platform/conf/locale/en/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/en/LC_MESSAGES/django.po
@@ -13046,3 +13046,86 @@ msgid ""
 "{display_name} is only accessible to enrolled learners. Sign in or register,"
 " and enroll in this course to view it."
 msgstr ""
+
+#. MITx Online theme - footer.html
+#: lms/templates/footer.html
+msgid "About Us"
+msgstr ""
+
+#. MITx Online theme - footer.html
+#: lms/templates/footer.html
+msgid "Accessibility"
+msgstr ""
+
+#. MITx Online theme - footer.html
+#: lms/templates/footer.html
+msgid "Help"
+msgstr ""
+
+#. MITx Online theme - footer.html
+#: lms/templates/footer.html
+msgid "Footer navigation"
+msgstr ""
+
+#. MITx Online theme - footer.html
+#: lms/templates/footer.html
+msgid "edX and Open edX are registered trademarks of edX LLC."
+msgstr ""
+
+#. MITx Online theme - navbar-authenticated.html
+#: lms/templates/header/navbar-authenticated.html
+#. Translators: This is short for "System administration".
+msgid "Sysadmin"
+msgstr ""
+
+#. MITx Online theme - navbar-authenticated.html, user_dropdown.html
+#: lms/templates/header/navbar-authenticated.html
+#: lms/templates/header/user_dropdown.html
+msgid "Dashboard"
+msgstr ""
+
+#. MITx Online theme - navbar-not-authenticated.html
+#: lms/templates/header/navbar-not-authenticated.html
+msgid "Supplemental Links"
+msgstr ""
+
+#. MITx Online theme - navbar-not-authenticated.html
+#: lms/templates/header/navbar-not-authenticated.html
+msgid "Explore courses"
+msgstr ""
+
+#. MITx Online theme - user_dropdown.html
+#: lms/templates/header/user_dropdown.html
+msgid "Options Menu"
+msgstr ""
+
+#. MITx Online theme - user_dropdown.html
+#: lms/templates/header/user_dropdown.html
+msgid "Dashboard for:"
+msgstr ""
+
+#. MITx Online theme - user_dropdown.html
+#: lms/templates/header/user_dropdown.html
+msgid "More Options"
+msgstr ""
+
+#. MITx Online theme - user_dropdown.html
+#: lms/templates/header/user_dropdown.html
+msgid "Profile"
+msgstr ""
+
+#. MITx Online theme - user_dropdown.html
+#: lms/templates/header/user_dropdown.html
+msgid "Accounts"
+msgstr ""
+
+#. MITx Online theme - user_dropdown.html
+#: lms/templates/header/user_dropdown.html
+msgid "Sign Out"
+msgstr ""
+
+#. MITx Online theme - navbar-logo-header.html
+#: lms/templates/header/navbar-logo-header.html
+#, python-brace-format
+msgid "{platform_name} Home Page"
+msgstr ""


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9923

### Description (What does it do?)
The header and footer of legacy theme pages did not respect the change of language.



### Screenshots (if appropriate):

<img width="1709" height="308" alt="Screenshot 2026-01-22 at 3 12 15 PM" src="https://github.com/user-attachments/assets/2e1aeb0c-88d2-4359-8b19-0dc8502c8e83" />


<img width="573" height="162" alt="Screenshot 2026-01-22 at 3 12 27 PM" src="https://github.com/user-attachments/assets/b59fb758-4396-41dc-b216-e5300ad1632f" />



### How can this be tested?

Please configure [this](https://github.com/mitodl/mitxonline-theme/tree/main
) theme locally with the steps mentioned here

https://mitodl.github.io/handbook/openedx/configuring_theme_in_edX.html


`tutor dev exec lms bash`

`export ATLAS_OPTIONS='--repository zamanafzal/mitxonline-translations --revision feature/add-ar-translations-20260122-100248'`

` make pull_translations`

Now you will see the header and footer content transalated for arabic. 


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
