### PR TITLE
feat: marked admin related strings with i18n

### DIFF
--- a/translations/edx-platform/conf/locale/en/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/en/LC_MESSAGES/django.po
@@ -13383,3 +13383,7 @@ msgstr ""
 #: lms/templates/staff_problem_info.html:31
 msgid "Submission history"
 msgstr ""
+
+#: lms/templates/preview_menu.html:101
+msgid "View in Studio"
+msgstr ""

--- a/translations/edx-platform/conf/locale/en/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/en/LC_MESSAGES/django.po
@@ -13189,6 +13189,11 @@ msgstr ""
 msgid "edX and Open edX are registered trademarks of edX LLC."
 msgstr ""
 
+#. MITx Online theme - navbar-authenticated.html
+#: lms/templates/header/navbar-authenticated.html
+#. Translators: This is short for "System administration".
+msgid "Sysadmin"
+msgstr ""
 
 #. MITx Online theme - navbar-authenticated.html, user_dropdown.html
 #: lms/templates/header/navbar-authenticated.html
@@ -13369,4 +13374,12 @@ msgstr ""
 
 #: lms/templates/courseware/progress.html
 msgid "No problem scores in this section"
+msgstr ""
+
+#: lms/templates/staff_problem_info.html:27
+msgid "Staff Debug Info"
+msgstr ""
+
+#: lms/templates/staff_problem_info.html:31
+msgid "Submission history"
 msgstr ""

--- a/translations/edx-platform/conf/locale/en/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/en/LC_MESSAGES/django.po
@@ -13189,12 +13189,6 @@ msgstr ""
 msgid "edX and Open edX are registered trademarks of edX LLC."
 msgstr ""
 
-#. MITx Online theme - navbar-authenticated.html
-#: lms/templates/header/navbar-authenticated.html
-#. Translators: This is short for "System administration".
-msgid "Sysadmin"
-msgstr ""
-
 #. MITx Online theme - navbar-authenticated.html, user_dropdown.html
 #: lms/templates/header/navbar-authenticated.html
 #: lms/templates/header/user_dropdown.html


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9923


### Description (What does it do?)
This PR adds admin-related strings to the **` en`** version so that they can be translated.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
