### PR TITLE
fix: updated question strings for french

### DIFF
--- a/translations/edx-platform/conf/locale/fr/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/fr/LC_MESSAGES/django.po
@@ -4145,9 +4145,9 @@ msgstr "Désactivé"
 #, python-brace-format
 msgid "({number} Question)"
 msgid_plural "({number} Questions)"
-msgstr[0] "(Question {number})"
-msgstr[1] "(Questions {number})"
-msgstr[2] "(Questions {number})"
+msgstr[0] "({number} Question)"
+msgstr[1] "({number} Questions)"
+msgstr[2] "({number} Questions)"
 
 #: lms/djangoapps/course_home_api/outline/views.py:293
 #, python-brace-format


### PR DESCRIPTION
### What are the relevant tickets?


### Description (What does it do?)
This will fix the translation of `{number} Questions` in the course outline for French. 

### Screenshots (if appropriate):


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
